### PR TITLE
Return Amazon SES response for each email sent

### DIFF
--- a/mailshake/mailers/amazon_ses.py
+++ b/mailshake/mailers/amazon_ses.py
@@ -36,6 +36,8 @@ class AmazonSESMailer(BaseMailer):
             logger.debug('No email messages to send')
             return
 
+        responses = []
+
         for msg in email_messages:
             destination_data = {
                 'ToAddresses': msg.to,
@@ -76,4 +78,8 @@ class AmazonSESMailer(BaseMailer):
                 data['ReturnPath'] = self.return_path
 
             logger.debug('Sending email from {0} to {1}'.format(msg.from_email, msg.to))
-            self.client.send_email(**data)
+            response = self.client.send_email(**data)
+            responses.append(response)
+
+        return responses
+


### PR DESCRIPTION
The boto3 client send_mail function returns the SES response. This is a dictionary which contains the MessageId, which is very useful for tracking replies to emails and identifying emails. I've just started using the SES Receiving emails feature in a project and in order to track email replies the Message-ID header of the email needs to be known.
Amazon SES will replace any Message-ID header with it's own, so the only way to keep track of replies which reference the Amazon-supplied Message-ID header is to record it and keep track of it in your code.
As far as I can tell, this change shouldn't break anything, nothing was returned before, now it returns a list of the SES responses which should each contain the MessageId.